### PR TITLE
MAINT set x-scale to log in lpi if param is log

### DIFF
--- a/pimp/evaluator/local_parameter_importance.py
+++ b/pimp/evaluator/local_parameter_importance.py
@@ -365,6 +365,7 @@ class LPI(AbstractEvaluator):
                             color_ = (1, 0, 0)
                         t.set_color(color_)
 
+                ax1.set_xscale('log' if self.cs.get_hyperparameter(param).log else 'linear')
                 plt.xlabel(param)
                 if self.scenario.run_obj == 'runtime':
                     ax1.set_ylabel('runtime [sec]', zorder=81, **self.LABEL_FONT)

--- a/pimp/importance/importance.py
+++ b/pimp/importance/importance.py
@@ -62,7 +62,7 @@ class Importance(object):
                ignored.
         :param verbose: Toggle output to stdout (not logging, but tqdm-progress bars)
         """
-        self.logger = logging.getLogger("Importance")
+        self.logger = logging.getLogger("pimp.Importance")
         self.rng = np.random.RandomState(seed)
         self._parameters_to_evaluate = parameters_to_evaluate
         self._evaluator = None


### PR DESCRIPTION
Sets x-axis on log-scale if the parameter is on logscale. Same as in [fanova-visualization](https://github.com/automl/fanova/blob/4494c2f042b1719fceff28e6255255bf2437f5e5/fanova/visualizer.py#L342-L345). Currently, it's just doing this on default now, @AndreBiedenkapp do you think it should be an argument or is it always better like this?