### PR TITLE
Issue/112 smac facade class name

### DIFF
--- a/pimp/evaluator/ablation.py
+++ b/pimp/evaluator/ablation.py
@@ -526,7 +526,7 @@ class Ablation(AbstractEvaluator):
         Method to plot a barchart of individual parameter contributions of the improvement from source to target
         """
         p_names = np.array(list(self.evaluated_parameter_importance.keys())[1:-1])
-        p_names_short = np.array(self.shorten_unique(p_names))
+        p_names_short = np.array(shorten_unique(p_names))
         p_importance = np.array([100 * self.evaluated_parameter_importance[p] for p in p_names])
         max_to_plot = min(len(p_names), self.MAX_PARAMS_TO_PLOT)
 
@@ -579,7 +579,7 @@ class Ablation(AbstractEvaluator):
         y_label = self.scenario.run_obj if self.scenario.run_obj != 'quality' else 'cost'
 
         path = list(self.predicted_parameter_performances.keys())
-        path = np.array(self.shorten_unique(path))
+        path = np.array(shorten_unique(path))
         max_to_plot = min(len(path), self.MAX_PARAMS_TO_PLOT)
         performances = list(self.predicted_parameter_performances.values())
         performances = np.array(performances).reshape((-1, 1))

--- a/pimp/importance/importance.py
+++ b/pimp/importance/importance.py
@@ -12,8 +12,7 @@ from smac.optimizer.smbo import get_types
 from smac.tae.execute_ta_run import StatusType
 from tqdm import tqdm
 
-from pimp.configspace import CategoricalHyperparameter, Configuration, \
-    impute_inactive_values
+from pimp.configspace import CategoricalHyperparameter, Configuration, impute_inactive_values
 from pimp.epm.base_epm import RandomForestWithInstances
 from pimp.epm.unlogged_epar_x_rfwi import UnloggedEPARXrfi
 from pimp.epm.unlogged_rfwi import Unloggedrfwi

--- a/pimp/pimp.py
+++ b/pimp/pimp.py
@@ -12,7 +12,6 @@ from typing import Dict
 from typing import Union
 
 import numpy as np
-from smac.facade.smac_facade import SMAC
 from smac.scenario.scenario import Scenario
 from smac.runhistory.runhistory import RunHistory, RunKey
 from smac.optimizer.objective import average_cost
@@ -20,6 +19,12 @@ from smac.tae.execute_ta_run_aclib import StatusType
 from ConfigSpace.configuration_space import Configuration
 from pimp.importance.importance import Importance
 from pimp.utils.io.cmd_reader import CMDs
+
+try:
+    from smac.facade.smac_ac_facade import SMAC4AC as SMAC
+except ModuleNotFoundError:
+    # Backwards-compatibility for SMAC <= 0.10.0
+    from smac.facade.smac_facade import SMAC
 
 __author__ = "Andre Biedenkapp"
 __copyright__ = "Copyright 2016, ML4AAD"


### PR DESCRIPTION
Fixing the issue #112, correcting class name. Keep backwards-compatibility with SMAC <= 0.10.0. also fix small typo leading to bug in ablation plots not being generated.