### PR TITLE
ADD support for ordinal hyperparameters

### DIFF
--- a/pimp/configspace/__init__.py
+++ b/pimp/configspace/__init__.py
@@ -7,4 +7,4 @@ from ConfigSpace.hyperparameters import CategoricalHyperparameter, FloatHyperpar
 from ConfigSpace.conditions import AndConjunction, OrConjunction, InCondition, EqualsCondition
 from ConfigSpace.exceptions import ForbiddenValueError
 from ConfigSpace.hyperparameters import UniformFloatHyperparameter, UniformIntegerHyperparameter, Constant, \
-    OrdinalHyperparameter
+    OrdinalHyperparameter, NumericalHyperparameter

--- a/pimp/evaluator/fanova.py
+++ b/pimp/evaluator/fanova.py
@@ -20,7 +20,7 @@ from matplotlib import pyplot as plt
 from smac.runhistory.runhistory import RunHistory
 from ConfigSpace.configuration_space import Configuration
 from ConfigSpace.util import impute_inactive_values
-from ConfigSpace.hyperparameters import CategoricalHyperparameter, Constant
+from ConfigSpace.hyperparameters import CategoricalHyperparameter, OrdinalHyperparameter, Constant
 
 try:
     from fanova import fANOVA as fanova_pyrfr
@@ -103,8 +103,7 @@ class fANOVA(AbstractEvaluator):
                 for c_idx, config in enumerate(self.X):
                     # print("{}/{}".format(c_idx, len(self.X)))
                     for p_idx, param in enumerate(self.cs.get_hyperparameters()):
-                        if not (isinstance(param, CategoricalHyperparameter) or
-                                isinstance(param, Constant)):
+                        if not isinstance(param, (CategoricalHyperparameter, OrdinalHyperparameter, Constant)):
                             # getting the parameters out of the hypercube setting as used in smac runhistory
                             self._X[c_idx][p_idx] = param._transform(self.X[c_idx][p_idx])
         else:

--- a/pimp/evaluator/local_parameter_importance.py
+++ b/pimp/evaluator/local_parameter_importance.py
@@ -14,7 +14,7 @@ mpl.use('Agg')
 from matplotlib import pyplot as plt
 
 from pimp.configspace import change_hp_value, Configuration, ForbiddenValueError,\
-    impute_inactive_values, CategoricalHyperparameter, check_forbidden
+    impute_inactive_values, CategoricalHyperparameter, NumericalHyperparameter, check_forbidden
 from pimp.evaluator.base_evaluator import AbstractEvaluator
 
 __author__ = "Andre Biedenkapp"
@@ -379,7 +379,7 @@ class LPI(AbstractEvaluator):
                             color_ = (1, 0, 0)
                         t.set_color(color_)
 
-                if not isinstance(self.cs.get_hyperparameter(param), CategoricalHyperparameter):
+                if isinstance(self.cs.get_hyperparameter(param), NumericalHyperparameter):
                     ax1.set_xscale('log' if self.cs.get_hyperparameter(param).log else 'linear')
                 plt.xlabel(param)
                 if self.scenario.run_obj == 'runtime':


### PR DESCRIPTION
If https://github.com/automl/fanova/pull/101 gets approved, we might as well support `OrdinalHyperparameter`s (roughly treating them the same way as `CategoricalHyperparameter`s.